### PR TITLE
[FEATURE] Use px for size units instead of rem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "@testing-library/jest-dom": "^5.17.0",
                 "@testing-library/react": "^16.2.0",
                 "@testing-library/user-event": "^13.5.0",
+                "@thedutchcoder/postcss-rem-to-px": "^0.0.2",
                 "@vitejs/plugin-react": "^4.3.3",
                 "axios": "^1.7.4",
                 "bcryptjs": "^2.4.3",
@@ -3108,6 +3109,18 @@
             },
             "peerDependencies": {
                 "@testing-library/dom": ">=7.21.4"
+            }
+        },
+        "node_modules/@thedutchcoder/postcss-rem-to-px": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@thedutchcoder/postcss-rem-to-px/-/postcss-rem-to-px-0.0.2.tgz",
+            "integrity": "sha512-M2T3bJSTgLtZF8+KDYDtSDAFGuTlaxYfitpjkmNswnfJ8AjbQ/g7NC+bqgAAViYWFV9I3tdrQuQ3Bu8j7GrjwA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.3.0"
             }
         },
         "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^13.5.0",
+        "@thedutchcoder/postcss-rem-to-px": "^0.0.2",
         "@vitejs/plugin-react": "^4.3.3",
         "axios": "^1.7.4",
         "bcryptjs": "^2.4.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 export default {
     plugins: {
         tailwindcss: {},
+        '@thedutchcoder/postcss-rem-to-px': {},
         autoprefixer: {},
     },
 };


### PR DESCRIPTION
### Description of change

add postcss plugin

### Pull-Request Checklist

- [✅] Code is up-to-date with the `main` branch
- [✅] `npm run lint` passes with this change
- [✅] `npm run test` passes with this change
- [✅] This pull request links relevant issues as `Fixes #14 `
- [✅] Basic testing has been done by developer
- [N/A] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [✅] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
